### PR TITLE
Make Docker's mount path compatible with Windows

### DIFF
--- a/examples/db/run_mysql.sh
+++ b/examples/db/run_mysql.sh
@@ -8,6 +8,12 @@ fi
 # get current dir
 CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+# make the directory format compatible with Windows
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
+    DRIVE="${CUR_DIR:1:1}"
+    CUR_DIR="${DRIVE^}:${CUR_DIR:2}"
+fi
+
 docker rm -f datagpt-example-mysql
 
 docker run -it \

--- a/examples/db/run_pg.sh
+++ b/examples/db/run_pg.sh
@@ -10,6 +10,13 @@ echo ${lang}
 # get current dir
 CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+# make the directory format compatible with Windows
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
+    DRIVE="${CUR_DIR:1:1}"
+    CUR_DIR="${DRIVE^}:${CUR_DIR:2}"
+fi
+
+
 echo "${CUR_DIR}/sql/${lang}/pg/*.sql"
 
 docker rm -f datagpt-example-pg


### PR DESCRIPTION
I found that the two startup database script files in the Example fail to launch on Windows. The reason behind this is that the value of CUR_DIR follows the Linux path convention, which is not compatible with Windows. Therefore, I have added a short condition to handle this and make it compatible.